### PR TITLE
[VOI-71] Proper wasm level exports

### DIFF
--- a/src/__tests__/fixtures/regular-macros-ast.mts
+++ b/src/__tests__/fixtures/regular-macros-ast.mts
@@ -14,7 +14,7 @@ export const regularMacrosAst = [
         ],
         [
           "regular-macro",
-          "let#754",
+          "let#764",
           ["parameters"],
           [
             "block",
@@ -38,7 +38,7 @@ export const regularMacrosAst = [
         ],
         [
           "regular-macro",
-          "fn#1011",
+          "fn#1243",
           ["parameters"],
           [
             "block",

--- a/src/__tests__/modules.test.mts
+++ b/src/__tests__/modules.test.mts
@@ -132,6 +132,7 @@ const input = {
     }),
   },
   srcPath: "/Users/drew/projects/void",
+  indexPath: "/Users/drew/projects/void/index.void",
   stdPath: "/Users/drew/projects/void/std",
 };
 

--- a/src/__tests__/regular-macros.test.mts
+++ b/src/__tests__/regular-macros.test.mts
@@ -15,6 +15,7 @@ describe("regular macro evaluation", () => {
     const resolvedModules = resolveFileModules({
       files,
       srcPath: path.dirname("test"),
+      indexPath: "test.void",
       stdPath: stdPath,
     });
     const result = expandRegularMacros(resolvedModules);

--- a/src/config/cli.mts
+++ b/src/config/cli.mts
@@ -44,11 +44,7 @@ export const getConfigFromCli = (): VoidConfig => {
     allowPositionals: true,
   });
 
-  const index = positionals[0];
-
-  if (typeof index !== "string") {
-    throw new Error("Expected void entry file path");
-  }
+  const index = positionals[0] ?? "./src";
 
   return {
     index,

--- a/src/lib/resolve-src.mts
+++ b/src/lib/resolve-src.mts
@@ -1,0 +1,35 @@
+import { stat } from "node:fs/promises";
+import path from "node:path";
+
+export type SrcInfo = {
+  indexPath: string;
+  srcRootPath?: string;
+};
+
+/**
+ * Resolves src code location information.
+ *
+ * Assumes either a single file to compile or a directory with an index file.
+ * I.E. Single File === `src/test.void` or Directory === `src`.
+ *
+ * Will return only the index file path if a single file is provided.
+ * Will return the srcRootPath and index file path as srcRootPath + index.void if a directory is provided.
+ */
+export async function resolveSrc(index: string): Promise<SrcInfo> {
+  const indexPath = path.resolve(index);
+  const parsedIndexPath = path.parse(indexPath);
+  const indexStats = await stat(indexPath);
+
+  if (!indexStats.isDirectory() && parsedIndexPath.ext !== ".void") {
+    throw new Error(`Invalid file extension ${parsedIndexPath.ext}`);
+  }
+
+  if (indexStats.isDirectory()) {
+    return {
+      indexPath: path.join(indexPath, "index.void"),
+      srcRootPath: indexPath,
+    };
+  }
+
+  return { indexPath };
+}

--- a/src/syntax-objects/module.mts
+++ b/src/syntax-objects/module.mts
@@ -11,6 +11,8 @@ import {
 
 export class VoidModule extends ScopedNamedEntity {
   readonly syntaxType = "module";
+  /** This module is the entry point of the user src code */
+  isIndex = false;
   value: Expr[] = [];
   /**
    * 0 = init,
@@ -25,11 +27,13 @@ export class VoidModule extends ScopedNamedEntity {
     opts: ScopedNamedEntityOpts & {
       value?: ListValue[];
       phase?: number;
+      isIndex?: boolean;
     }
   ) {
     super(opts);
     if (opts.value) this.push(...opts.value);
     this.phase = opts.phase ?? 0;
+    this.isIndex = opts.isIndex ?? false;
   }
 
   getPath(): string[] {


### PR DESCRIPTION
Void now uses the entry file as the index for wasm module level exports. So functions exported from that file, will be exported from the emitted wasm binary.