### PR TITLE
[VOI-87] Improved Structural Object Support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "@types/uniqid": "^4.1.3",
-        "binaryen": "^118.0.0",
+        "binaryen": "^119.0.0",
         "commander": "^5.1.0",
         "eventemitter2": "^6.4.2",
         "glob": "^10.3.10",
@@ -1374,9 +1374,10 @@
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
     },
     "node_modules/binaryen": {
-      "version": "118.0.0",
-      "resolved": "https://registry.npmjs.org/binaryen/-/binaryen-118.0.0.tgz",
-      "integrity": "sha512-KzekjPjpLE1zk29BKQSHNWLSHPYAfa80lcsIi5bDnev8vyfDyiMCVFPjaplhfXIKs7LI3r1RPyhoAj4qsRQwwg==",
+      "version": "119.0.0",
+      "resolved": "https://registry.npmjs.org/binaryen/-/binaryen-119.0.0.tgz",
+      "integrity": "sha512-DTdcs8ijrj2OIEftWVPVkYsgJ8MzlYH+uSsC8156g88E7CNaG8kEfWNGSXxb3tPlzadrm6sD3mgSEKKZJu4Q3g==",
+      "license": "Apache-2.0",
       "bin": {
         "wasm-as": "bin/wasm-as",
         "wasm-ctor-eval": "bin/wasm-ctor-eval",
@@ -4598,9 +4599,9 @@
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
     },
     "binaryen": {
-      "version": "118.0.0",
-      "resolved": "https://registry.npmjs.org/binaryen/-/binaryen-118.0.0.tgz",
-      "integrity": "sha512-KzekjPjpLE1zk29BKQSHNWLSHPYAfa80lcsIi5bDnev8vyfDyiMCVFPjaplhfXIKs7LI3r1RPyhoAj4qsRQwwg=="
+      "version": "119.0.0",
+      "resolved": "https://registry.npmjs.org/binaryen/-/binaryen-119.0.0.tgz",
+      "integrity": "sha512-DTdcs8ijrj2OIEftWVPVkYsgJ8MzlYH+uSsC8156g88E7CNaG8kEfWNGSXxb3tPlzadrm6sD3mgSEKKZJu4Q3g=="
     },
     "brace-expansion": {
       "version": "1.1.11",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   },
   "dependencies": {
     "@types/uniqid": "^4.1.3",
-    "binaryen": "^118.0.0",
+    "binaryen": "^119.0.0",
     "commander": "^5.1.0",
     "eventemitter2": "^6.4.2",
     "glob": "^10.3.10",

--- a/src/__tests__/compiler.test.ts
+++ b/src/__tests__/compiler.test.ts
@@ -51,6 +51,9 @@ describe("E2E Compiler Pipeline", () => {
       12,
       4,
       597, // Modules
+      9, // Generic impls
+      17,
+      82,
     ]);
   });
 

--- a/src/__tests__/fixtures/e2e-file.ts
+++ b/src/__tests__/fixtures/e2e-file.ts
@@ -166,6 +166,18 @@ pub fn test13()
   let c = a.do_work(b)
   c.z // 9
 
+// Test structural object field access
+fn get_y_field(obj: { y: i32 }) -> i32
+  obj.y
+
+pub fn test14()
+  let obj = { y: 17, z: 689 }
+  get_y_field(obj)
+
+// Test that structural parameters can accept matching nominal types
+pub fn test15() -> i32
+  let point = Point { x: 1, y: 82, z: 3 }
+  get_y_field(point)
 `;
 
 export const tcoText = `

--- a/src/assembler.ts
+++ b/src/assembler.ts
@@ -433,6 +433,9 @@ const buildDsArrayType = (opts: CompileExprOpts, type: DsArrayType) => {
   return type.binaryenType;
 };
 
+// Marks the start of the fields in an object after RTT info fields
+const OBJECT_FIELDS_OFFSET = 2;
+
 /** TODO: Skip building types for object literals that are part of an initializer of an obj */
 const buildObjectType = (opts: CompileExprOpts, obj: ObjectType): TypeRef => {
   if (obj.binaryenType) return obj.binaryenType;
@@ -442,10 +445,14 @@ const buildObjectType = (opts: CompileExprOpts, obj: ObjectType): TypeRef => {
   const binaryenType = defineStructType(mod, {
     name: obj.id,
     fields: [
+      // Reference to the RTT Ancestors Table
       {
         type: opts.extensionHelpers.i32Array,
-        name: "ancestors",
+        name: "__ancestors",
       },
+      // Reference to the field index lookup function
+      // TODO
+      // Fields
       ...obj.fields.map((field) => ({
         type: mapBinaryenType(opts, field.type!),
         name: field.name,
@@ -481,7 +488,7 @@ const compileObjMemberAccess = (opts: CompileExprOpts<Call>) => {
   const member = expr.identifierArgAt(1);
   const objValue = compileExpression({ ...opts, expr: obj });
   const type = getExprType(obj) as ObjectType;
-  const memberIndex = type.getFieldIndex(member) + 1; // +1 to account for the RTT table
+  const memberIndex = type.getFieldIndex(member) + OBJECT_FIELDS_OFFSET;
   const field = type.getField(member)!;
   return structGetFieldValue({
     mod,

--- a/src/assembler.ts
+++ b/src/assembler.ts
@@ -34,7 +34,6 @@ import { initFieldLookupHelpers } from "./assembler/field-lookup-helpers.js";
 
 export const assemble = (ast: Expr) => {
   const mod = new binaryen.Module();
-  mod.setMemory(1, 150, "buffer");
   mod.setFeatures(binaryen.Features.All);
   const extensionHelpers = initExtensionHelpers(mod);
   const fieldLookupHelpers = initFieldLookupHelpers(mod);

--- a/src/assembler.ts
+++ b/src/assembler.ts
@@ -236,7 +236,7 @@ const compileObjectInit = (opts: CompileExprOpts<Call>) => {
     ),
     mod.global.get(
       `__field_index_table_${objectType.id}`,
-      opts.extensionHelpers.i32Array
+      opts.fieldLookupHelpers.lookupTableType
     ),
     ...obj.fields.map((field) =>
       compileExpression({
@@ -390,7 +390,7 @@ const compileObjectLiteral = (opts: CompileExprOpts<ObjectLiteral>) => {
     ),
     mod.global.get(
       `__field_index_table_${objectType.id}`,
-      opts.extensionHelpers.i32Array
+      opts.fieldLookupHelpers.lookupTableType
     ),
     ...obj.fields.map((field) =>
       compileExpression({ ...opts, expr: field.initializer })
@@ -501,7 +501,7 @@ const buildObjectType = (opts: CompileExprOpts, obj: ObjectType): TypeRef => {
   // Set RTT Table (So we don't have to re-calculate it every time)
   mod.addGlobal(
     `__field_index_table_${obj.id}`,
-    opts.extensionHelpers.i32Array,
+    opts.fieldLookupHelpers.lookupTableType,
     false,
     opts.fieldLookupHelpers.initFieldIndexTable({ ...opts, expr: obj })
   );

--- a/src/assembler/field-lookup-helpers.ts
+++ b/src/assembler/field-lookup-helpers.ts
@@ -10,44 +10,46 @@ import {
 
 const bin = binaryen as unknown as AugmentedBinaryen;
 
-export const initExtensionHelpers = (mod: binaryen.Module) => {
-  const i32Array = defineArrayType(mod, bin.i32, true);
+/** DOES NOT ACCOUNT FOR FIELD OFFSET */
+export const initFieldLookupHelpers = (mod: binaryen.Module) => {
+  const lookupTableType = defineArrayType(mod, bin.i32, true);
+  const LOOKUP_NAME = "__lookup_field_index";
 
   mod.addFunction(
-    "__extends",
-    // Extension Obj Id, Ancestor Ids Array
-    bin.createType([bin.i32, i32Array]),
+    LOOKUP_NAME,
+    // Field hash int, Field lookup table
+    bin.createType([bin.i32, lookupTableType]),
     bin.i32,
-    [bin.i32], // Current index, Does Extend
+    [bin.i32], // Current index parameter
     mod.block(null, [
-      mod.local.set(2, mod.i32.const(0)), // Current ancestor index
+      mod.local.set(2, mod.i32.const(0)), // Current field index
       mod.loop(
         "loop",
         mod.block(null, [
-          // We've reached the end of the ancestor table without finding a match, return false
+          // Trap if we've reached the end of the field table, the compiler messed up
           mod.if(
             mod.i32.eq(
               mod.local.get(2, bin.i32),
-              arrayLen(mod, mod.local.get(1, i32Array))
+              arrayLen(mod, mod.local.get(1, lookupTableType))
             ),
-            mod.return(mod.i32.const(0))
+            mod.unreachable()
           ),
 
-          // Check if we've found the ancestor
+          // Check if we've found the field
           mod.if(
             mod.i32.eq(
               mod.local.get(0, bin.i32),
               arrayGet(
                 mod,
-                mod.local.get(1, i32Array),
+                mod.local.get(1, lookupTableType),
                 mod.local.get(2, bin.i32),
                 bin.i32,
                 false
               )
             ),
 
-            // If we have, set doesExtend to true and break
-            mod.return(mod.i32.const(1))
+            // If we have return the current index, as it matches the field index
+            mod.return(mod.local.get(2, bin.i32))
           ),
 
           // Increment ancestor index
@@ -61,13 +63,13 @@ export const initExtensionHelpers = (mod: binaryen.Module) => {
     ])
   );
 
-  const initExtensionArray = (ancestorIds: number[]) => {
+  const initFieldIndexTable = (fields: number[]) => {
     return arrayNewFixed(
       mod,
-      binaryenTypeToHeapType(i32Array),
-      ancestorIds.map((id) => mod.i32.const(id))
+      binaryenTypeToHeapType(lookupTableType),
+      fields.map((id) => mod.i32.const(id))
     );
   };
 
-  return { initExtensionArray, i32Array };
+  return { initFieldIndexTable, lookupTableType, LOOKUP_NAME };
 };

--- a/src/assembler/field-lookup-helpers.ts
+++ b/src/assembler/field-lookup-helpers.ts
@@ -13,7 +13,7 @@ import {
   callRef,
   refCast,
 } from "../lib/binaryen-gc/index.js";
-import { ObjectType } from "../syntax-objects/types.js";
+import { ObjectType, voidBaseObject } from "../syntax-objects/types.js";
 import { murmurHash3 } from "../lib/murmur-hash.js";
 import {
   compileExpression,
@@ -113,14 +113,18 @@ export const initFieldLookupHelpers = (mod: binaryen.Module) => {
 
         const accessor = mod.addFunction(
           accessorName,
-          bin.createType([mapBinaryenType(opts, obj)]),
+          bin.createType([mapBinaryenType(opts, voidBaseObject)]),
           mapBinaryenType(opts, field.type!),
           [],
           structGetFieldValue({
             mod,
             fieldType: mapBinaryenType(opts, field.type!),
             fieldIndex: index + 2, // Skip RTT type fields
-            exprRef: mod.local.get(0, mapBinaryenType(opts, obj)),
+            exprRef: refCast(
+              mod,
+              mod.local.get(0, mapBinaryenType(opts, voidBaseObject)),
+              mapBinaryenType(opts, obj)
+            ),
           })
         );
 

--- a/src/assembler/field-lookup-helpers.ts
+++ b/src/assembler/field-lookup-helpers.ts
@@ -6,20 +6,34 @@ import {
   arrayGet,
   arrayNewFixed,
   binaryenTypeToHeapType,
+  defineStructType,
+  initStruct,
+  structGetFieldValue,
+  refFunc,
 } from "../lib/binaryen-gc/index.js";
+import { ObjectType } from "../syntax-objects/types.js";
+import { murmurHash3 } from "../lib/murmur-hash.js";
+import { CompileExprOpts, mapBinaryenType } from "../assembler.js";
 
 const bin = binaryen as unknown as AugmentedBinaryen;
 
 /** DOES NOT ACCOUNT FOR FIELD OFFSET */
 export const initFieldLookupHelpers = (mod: binaryen.Module) => {
-  const lookupTableType = defineArrayType(mod, bin.i32, true);
-  const LOOKUP_NAME = "__lookup_field_index";
+  const fieldAccessorStruct = defineStructType(mod, {
+    name: "FieldAccessor",
+    fields: [
+      { name: "__field_hash", type: bin.i32, mutable: false },
+      { name: "__field_accessor", type: bin.funcref, mutable: false },
+    ],
+  });
+  const lookupTableType = defineArrayType(mod, fieldAccessorStruct, true);
+  const LOOKUP_NAME = "__lookup_field_accessor";
 
   mod.addFunction(
     LOOKUP_NAME,
     // Field hash int, Field lookup table
     bin.createType([bin.i32, lookupTableType]),
-    bin.i32,
+    bin.funcref, // Field accessor
     [bin.i32], // Current index parameter
     mod.block(null, [
       mod.local.set(2, mod.i32.const(0)), // Current field index
@@ -39,17 +53,35 @@ export const initFieldLookupHelpers = (mod: binaryen.Module) => {
           mod.if(
             mod.i32.eq(
               mod.local.get(0, bin.i32),
-              arrayGet(
+              structGetFieldValue({
                 mod,
-                mod.local.get(1, lookupTableType),
-                mod.local.get(2, bin.i32),
-                bin.i32,
-                false
-              )
+                fieldType: bin.i32,
+                fieldIndex: 0,
+                exprRef: arrayGet(
+                  mod,
+                  mod.local.get(1, lookupTableType),
+                  mod.local.get(2, bin.i32),
+                  bin.i32,
+                  false
+                ),
+              })
             ),
 
-            // If we have return the current index, as it matches the field index
-            mod.return(mod.local.get(2, bin.i32))
+            // If we have return the accessor function
+            mod.return(
+              structGetFieldValue({
+                mod,
+                fieldType: bin.funcref,
+                fieldIndex: 1,
+                exprRef: arrayGet(
+                  mod,
+                  mod.local.get(1, lookupTableType),
+                  mod.local.get(2, bin.i32),
+                  bin.i32,
+                  false
+                ),
+              })
+            )
           ),
 
           // Increment ancestor index
@@ -63,11 +95,32 @@ export const initFieldLookupHelpers = (mod: binaryen.Module) => {
     ])
   );
 
-  const initFieldIndexTable = (fields: number[]) => {
+  const initFieldIndexTable = (opts: CompileExprOpts<ObjectType>) => {
+    const { mod, expr: obj } = opts;
     return arrayNewFixed(
       mod,
       binaryenTypeToHeapType(lookupTableType),
-      fields.map((id) => mod.i32.const(id))
+      obj.fields.map((field, index) => {
+        const accessorName = `obj_field_accessor_${obj.id}_${field.name}`;
+
+        mod.addFunction(
+          accessorName,
+          bin.createType([mapBinaryenType(opts, obj)]),
+          mapBinaryenType(opts, field.type!),
+          [],
+          structGetFieldValue({
+            mod,
+            fieldType: mapBinaryenType(opts, field.type!),
+            fieldIndex: index,
+            exprRef: mod.local.get(0, mapBinaryenType(opts, obj)),
+          })
+        );
+
+        return initStruct(mod, fieldAccessorStruct, [
+          murmurHash3(field.name),
+          refFunc(mod, accessorName),
+        ]);
+      })
     );
   };
 

--- a/src/cli/exec.ts
+++ b/src/cli/exec.ts
@@ -1,6 +1,5 @@
 import { stdout } from "process";
 import { getConfig } from "../lib/config/index.js";
-import { assemble } from "../assembler.js";
 import { run } from "../run.js";
 import { processSemantics } from "../semantics/index.js";
 import binaryen from "binaryen";

--- a/src/lib/__tests__/murmur-hash.test.ts
+++ b/src/lib/__tests__/murmur-hash.test.ts
@@ -1,0 +1,51 @@
+import { test, expect, describe } from "vitest";
+import { murmurHash3 } from "../murmur-hash.js";
+
+describe("Murmur Hash", async () => {
+  test("should return correct hash for an empty string", () => {
+    const hash = murmurHash3("");
+    expect(hash).toBe(0);
+  });
+
+  test("should return correct hash for a short string", () => {
+    const hash = murmurHash3("abc");
+    expect(hash).toBe(3017643002);
+  });
+
+  test("should return correct hash for a longer string", () => {
+    const hash = murmurHash3("The quick brown fox jumps over the lazy dog");
+    expect(hash).toBe(776992547);
+  });
+
+  test("should return correct hash for string with special characters", () => {
+    const hash = murmurHash3("!@#$%^&*()");
+    expect(hash).toBe(3947575985);
+  });
+
+  test("should return correct hash for numeric string", () => {
+    const hash = murmurHash3("1234567890");
+    expect(hash).toBe(839148365);
+  });
+
+  test("should return consistent hash for the same input", () => {
+    const hash1 = murmurHash3("consistent");
+    const hash2 = murmurHash3("consistent");
+    expect(hash1).toBe(hash2);
+  });
+
+  test("should return different hashes for different inputs", () => {
+    const hash1 = murmurHash3("input1");
+    const hash2 = murmurHash3("input2");
+    expect(hash1).not.toBe(hash2);
+  });
+
+  test("should handle non-ASCII characters", () => {
+    const hash = murmurHash3("你好，世界");
+    expect(hash).toBe(1975738373);
+  });
+
+  test("should return correct hash with non-zero seed", () => {
+    const hash = murmurHash3("seeded", 123);
+    expect(hash).toBe(1693092115);
+  });
+});

--- a/src/lib/binaryen-gc/index.ts
+++ b/src/lib/binaryen-gc/index.ts
@@ -109,8 +109,33 @@ export const modBinaryenTypeToHeapType = (
   return bin._BinaryenTypeGetHeapType(type);
 };
 
-export const refFunc = (mod: binaryen.Module, func: string): ExpressionRef =>
-  bin._BinaryenRefFunc(mod.ptr, func, binaryen.funcref);
+export const callRef = (
+  module: binaryen.Module,
+  target: ExpressionRef,
+  operands: ExpressionRef[],
+  returnType: TypeRef,
+  isReturn = false
+): ExpressionRef => {
+  const operandsPtr = allocU32Array(operands);
+  const result = bin._BinaryenCallRef(
+    module.ptr,
+    target,
+    operandsPtr,
+    operands.length,
+    returnType,
+    isReturn
+  );
+
+  bin._free(operandsPtr);
+  return result;
+};
+
+export const refFunc = (
+  mod: binaryen.Module,
+  func: string,
+  type: TypeRef
+): ExpressionRef =>
+  bin._BinaryenRefFunc(mod.ptr, bin.stringToUTF8OnStack(func), type);
 
 export const refCast = (
   mod: binaryen.Module,

--- a/src/lib/binaryen-gc/index.ts
+++ b/src/lib/binaryen-gc/index.ts
@@ -109,6 +109,9 @@ export const modBinaryenTypeToHeapType = (
   return bin._BinaryenTypeGetHeapType(type);
 };
 
+export const refFunc = (mod: binaryen.Module, func: string): ExpressionRef =>
+  bin._BinaryenRefFunc(mod.ptr, func, binaryen.funcref);
+
 export const refCast = (
   mod: binaryen.Module,
   ref: ExpressionRef,
@@ -123,7 +126,7 @@ export const refTest = (
 
 export const initStruct = (
   mod: binaryen.Module,
-  structType: HeapTypeRef,
+  structType: TypeRef,
   values: ExpressionRef[]
 ): ExpressionRef => {
   const structNewArgs = allocU32Array(values);
@@ -131,7 +134,7 @@ export const initStruct = (
     mod.ptr,
     structNewArgs,
     values.length,
-    structType
+    binaryenTypeToHeapType(structType)
   );
   bin._free(structNewArgs);
   return structNew;

--- a/src/lib/binaryen-gc/types.ts
+++ b/src/lib/binaryen-gc/types.ts
@@ -44,6 +44,11 @@ export type AugmentedBinaryen = typeof binaryen & {
     ref: ExpressionRef,
     type: TypeRef
   ): ExpressionRef;
+  _BinaryenRefFunc(
+    module: ModuleRef,
+    func: string,
+    type: TypeRef
+  ): ExpressionRef;
   _BinaryenTypeGetHeapType(type: TypeRef): HeapTypeRef;
   _BinaryenArrayTypeGetElementType(heapType: HeapTypeRef): TypeRef;
   _BinaryenStructTypeGetNumFields(heapType: HeapTypeRef): Index;

--- a/src/lib/binaryen-gc/types.ts
+++ b/src/lib/binaryen-gc/types.ts
@@ -46,9 +46,19 @@ export type AugmentedBinaryen = typeof binaryen & {
   ): ExpressionRef;
   _BinaryenRefFunc(
     module: ModuleRef,
-    func: string,
+    funcName: number,
     type: TypeRef
   ): ExpressionRef;
+  _BinaryenCallRef(
+    module: ModuleRef,
+    target: ExpressionRef,
+    operands: ArrayRef<ExpressionRef>,
+    numOperands: Index,
+    type: TypeRef,
+    isReturn: bool
+  ): ExpressionRef;
+  _BinaryenFunctionGetType(func: binaryen.FunctionRef): HeapTypeRef;
+  _BinaryenHeapTypeIsSignature(heapType: HeapTypeRef): bool;
   _BinaryenTypeGetHeapType(type: TypeRef): HeapTypeRef;
   _BinaryenArrayTypeGetElementType(heapType: HeapTypeRef): TypeRef;
   _BinaryenStructTypeGetNumFields(heapType: HeapTypeRef): Index;

--- a/src/lib/murmur-hash.ts
+++ b/src/lib/murmur-hash.ts
@@ -1,0 +1,48 @@
+export const murmurHash3 = (key: string, seed: number = 0): number => {
+  let h1 = seed;
+  const remainder = key.length % 4;
+  const bytes = key.length - remainder;
+  const c1 = 0xcc9e2d51;
+  const c2 = 0x1b873593;
+
+  for (let i = 0; i < bytes; i += 4) {
+    let k1 =
+      (key.charCodeAt(i) & 0xff) |
+      ((key.charCodeAt(i + 1) & 0xff) << 8) |
+      ((key.charCodeAt(i + 2) & 0xff) << 16) |
+      ((key.charCodeAt(i + 3) & 0xff) << 24);
+
+    k1 = Math.imul(k1, c1);
+    k1 = (k1 << 15) | (k1 >>> 17);
+    k1 = Math.imul(k1, c2);
+
+    h1 ^= k1;
+    h1 = (h1 << 13) | (h1 >>> 19);
+    h1 = Math.imul(h1, 5) + 0xe6546b64;
+  }
+
+  let k1 = 0;
+
+  switch (remainder) {
+    case 3:
+      k1 ^= (key.charCodeAt(bytes + 2) & 0xff) << 16;
+    case 2:
+      k1 ^= (key.charCodeAt(bytes + 1) & 0xff) << 8;
+    case 1:
+      k1 ^= key.charCodeAt(bytes) & 0xff;
+      k1 = Math.imul(k1, c1);
+      k1 = (k1 << 15) | (k1 >>> 17);
+      k1 = Math.imul(k1, c2);
+      h1 ^= k1;
+  }
+
+  h1 ^= key.length;
+
+  h1 ^= h1 >>> 16;
+  h1 = Math.imul(h1, 0x85ebca6b);
+  h1 ^= h1 >>> 13;
+  h1 = Math.imul(h1, 0xc2b2ae35);
+  h1 ^= h1 >>> 16;
+
+  return h1 >>> 0;
+};

--- a/src/semantics/init-entities.ts
+++ b/src/semantics/init-entities.ts
@@ -334,11 +334,13 @@ const initNominalObjectType = (obj: List) => {
 };
 
 const initObjectType = (obj: List) => {
-  return new ObjectType({
+  const result = new ObjectType({
     ...obj.metadata,
     name: obj.syntaxId.toString(),
     value: extractObjectFields(obj),
   });
+  result.setAttribute("isStructural", true);
+  return result;
 };
 
 export const initMatch = (match: List): Match => {

--- a/src/semantics/init-entities.ts
+++ b/src/semantics/init-entities.ts
@@ -283,7 +283,7 @@ const initTypeExprEntities = (type?: Expr): Expr | undefined => {
   }
 
   if (type.calls("object")) {
-    return initObjectType(type);
+    return initStructuralObjectType(type);
   }
 
   if (type.calls("DsArray")) {
@@ -333,7 +333,7 @@ const initNominalObjectType = (obj: List) => {
   });
 };
 
-const initObjectType = (obj: List) => {
+const initStructuralObjectType = (obj: List) => {
   const result = new ObjectType({
     ...obj.metadata,
     name: obj.syntaxId.toString(),

--- a/src/semantics/resolution/resolve-types.ts
+++ b/src/semantics/resolution/resolve-types.ts
@@ -8,6 +8,7 @@ import {
   DsArrayType,
   ObjectType,
   TypeAlias,
+  voidBaseObject,
 } from "../../syntax-objects/types.js";
 import { Variable } from "../../syntax-objects/variable.js";
 import { getExprType } from "./get-expr-type.js";
@@ -106,7 +107,9 @@ const resolveObjectLiteralTypes = (obj: ObjectLiteral) => {
         typeExpr: f.initializer,
         type: f.type,
       })),
+      parentObj: voidBaseObject,
     });
+    obj.type.setAttribute("isStructural", true);
   }
 
   return obj;

--- a/src/semantics/resolution/types-are-equivalent.ts
+++ b/src/semantics/resolution/types-are-equivalent.ts
@@ -18,10 +18,11 @@ export const typesAreEquivalent = (
   }
 
   if (a.isObjectType() && b.isObjectType()) {
+    const structural = opts.structuralOnly || b.getAttribute("isStructural");
     if (opts.exactNominalMatch) return a.id === b.id;
 
     return (
-      (opts.structuralOnly || a.extends(b)) &&
+      (structural || a.extends(b)) &&
       b.fields.every((field) => {
         const match = a.fields.find((f) => f.name === field.name);
         return match && typesAreEquivalent(field.type, match.type);

--- a/src/syntax-objects/types.ts
+++ b/src/syntax-objects/types.ts
@@ -161,7 +161,12 @@ export class TupleType extends BaseType {
   }
 }
 
-export type ObjectField = { name: string; typeExpr: Expr; type?: Type };
+export type ObjectField = {
+  name: string;
+  typeExpr: Expr;
+  type?: Type;
+  binaryenAccessorType?: number;
+};
 
 export class ObjectType extends BaseType implements ScopedEntity {
   readonly kindOfType = "object";


### PR DESCRIPTION
Structural object types now use RTT field lookups. Now, a structural type will work with any type with a matching set of fields, nominal or structural.

Before this change, structural object types would only work with other structural objects that had the exact same fields, no more, no less. Which wasn't super useful.